### PR TITLE
Use add_compile_options instead of manually setting CXX_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,6 @@ endif()
 		if(MSVC)
 			set_target_properties(RCCpp-DearImGui-GLFW-example PROPERTIES COMPILE_FLAGS "/FC /utf-8")
 		else()
-			Set(CMAKE_CXX_FLAGS  "-DCOMPILE_PATH=\"\\\"$(PWD)\\\"\"")
+			add_compile_options("-DCOMPILE_PATH=\"\\\"$(PWD)\\\"\"")
 		endif()
 


### PR DESCRIPTION
This fixes building with Ninja Multi-Config, and also should be more robust in general.